### PR TITLE
Update to 1.4.0

### DIFF
--- a/Classes/ios/SDAPIRequest.h
+++ b/Classes/ios/SDAPIRequest.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) NSDictionary *params;
 @property (nonatomic, copy) NSData * bodyData;
 @property (nonatomic, strong) NSURL *fixedURL;
+@property (nonatomic, strong) NSString *acceptHeader;
 
 - (id)initWithPath:(NSString *)path;
 - (id)initWithPath:(NSString *)path params:(NSDictionary *)params;

--- a/Classes/ios/SDArtist.h
+++ b/Classes/ios/SDArtist.h
@@ -24,6 +24,9 @@
 
 @property (strong, nonatomic) NSString *SDURL;
 
+//This isnt returned by the locker call itself, but is in the search api. which is what we currently use to get artist images.
+@property (strong, nonatomic) NSString *imageURL;
+
 - (id)initWithDictionary:(NSDictionary *)apiDictionary;
 
 

--- a/Classes/ios/SDLockerHelper.h
+++ b/Classes/ios/SDLockerHelper.h
@@ -1,0 +1,27 @@
+//
+//  SDLocker.h
+//  7digital
+//
+//  Created by Daniel Too on 3/04/14.
+//  Copyright (c) 2014 7digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SDRelease.h"
+#import "SDTrack.h"
+#import "SDArtist.h"
+
+/**
+ 
+ This is a request to return releases from a user's locker (library of all purchased tracks).
+ 
+ */
+
+@class SDAPIResponse;
+
+@interface SDLockerHelper : NSObject
+
++ (void)requestLockerForCurrentUserWithParams:(NSDictionary *)params completion:(void(^)(SDAPIResponse *response, NSArray *releasesArray, NSError *error))completion;
+
+
+@end

--- a/Classes/ios/SDMedia.h
+++ b/Classes/ios/SDMedia.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, kSDMediaType) {
 
 /**
  Returns a URL for a 7digital track appropriate for streaming or downloading.  The NSURL will contain all of the appropriate oAuth parameters for the logged in user.
- See the 7Digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
+ See the 7digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
  
  @see kSDMediaType for
  @param track           The SDTrack object for the song
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, kSDMediaType) {
 
 /**
  Returns a URL for a 7digital track appropriate for a preview stream.  The NSURL will contain all of the appropriate oAuth parameters for the logged in user.
- See the 7Digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
+ See the 7digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
  
  @param track           The SDTrack object for the song
  

--- a/Classes/ios/SDPlaylistHeader.h
+++ b/Classes/ios/SDPlaylistHeader.h
@@ -1,0 +1,24 @@
+//
+//  SDPlaylistHeader.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistHeader : NSObject
+
+
+@property (nonatomic,strong) NSString * playlistTitle;
+@property (nonatomic,strong) NSString * playlistID;
+@property (nonatomic) BOOL publicPlaylist;
+@property (nonatomic,strong) NSDate * lastUpdated;
+@property (nonatomic) NSInteger * trackCount;
+@property (nonatomic,strong) NSString * imageURlString;
+//these two I dont use so I'm just gonna pass you the array of NSDictionaries.
+@property (nonatomic,strong) NSArray * annotations;
+@property (nonatomic,strong) NSArray * links;
+
+@end

--- a/Classes/ios/SDPlaylistHelper.h
+++ b/Classes/ios/SDPlaylistHelper.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "SDPlaylistTrack.h"
 
-@interface SDPlaylist : NSObject
+@interface SDPlaylistHelper : NSObject
 
 
 /**

--- a/Classes/ios/SDPlaylistMetadata.h
+++ b/Classes/ios/SDPlaylistMetadata.h
@@ -1,0 +1,29 @@
+//
+//  SDPlaylistHeader.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistMetadata : NSObject
+
+@property (nonatomic, strong) NSString *playlistTitle;
+
+@property (nonatomic, strong) NSString *playlistID;
+
+@property (nonatomic, assign) BOOL publicPlaylist;
+
+@property (nonatomic, strong) NSDate *lastUpdated;
+
+@property (nonatomic, assign) NSInteger trackCount;
+
+@property (nonatomic, strong) NSString *imageURlString;
+
+//these two I dont use so I'm just gonna pass you the array of NSDictionaries.
+@property (nonatomic, strong) NSArray *annotations;
+@property (nonatomic, strong) NSArray *links;
+
+@end

--- a/Classes/ios/SDPlaylistTrack.h
+++ b/Classes/ios/SDPlaylistTrack.h
@@ -1,0 +1,48 @@
+//
+//  SDPlaylistTrack.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 30/09/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistTrack : NSObject
+
+//the unique identifer for this track in the playlist.
+@property (strong, nonatomic) NSString * playlistTrackID;
+
+//the general track ID (may match to a track of origin 7digital, iTunes, Android)
+@property (strong, nonatomic) NSString * trackID;
+
+@property (strong, nonatomic) NSString * trackTitle;
+
+@property (strong, nonatomic) NSString * artistAppearsAs;
+
+//release properties
+@property (assign, nonatomic) NSInteger releaseId;
+
+@property (strong, nonatomic) NSString * releaseTitle;
+
+@property (strong, nonatomic) NSString * releaseArtistAppearsAs;
+
+@property (strong, nonatomic) NSString * releaseVersion;
+
+//the source of the track (i'm using "7digital" for 7digital tracks, and "itunes" for my users itunes tracks)
+@property (strong, nonatomic) NSString * source;
+
+@property (strong, nonatomic) NSString * audioUrl;
+
+@property (strong, nonatomic) NSDictionary * user;
+
+@property (strong, nonatomic) NSDate * dateAdded;
+
+@property (strong, nonatomic) NSString * imageString;
+
+
+//population method pass a single dictionary from the tracks array to populate
+- (id)initWithDictionary:(NSDictionary *)apiDictionary;
+
+
+@end

--- a/Classes/ios/SDRelease.h
+++ b/Classes/ios/SDRelease.h
@@ -12,7 +12,7 @@
 
 /**
  
- This is an object to represent a 7Digital Release (An album, single, EP etc)
+ This is an object to represent a 7digital Release (An album, single, EP etc)
  
  */
 
@@ -38,6 +38,8 @@
 
 @property (strong, nonatomic) NSArray *tracks;
 
+//unfortunately some albulms get taken down from 7digital by the rights holders this indicates if it has.
+@property (assign, nonatomic) BOOL available;
 
 /**
  

--- a/Classes/ios/SDSearch.h
+++ b/Classes/ios/SDSearch.h
@@ -1,0 +1,72 @@
+//
+//  SDSearch.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 15/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDSearch : NSObject
+
+//Artist
+/**
+ a basic search.
+ 
+ @param searchString    the string to search for.
+ 
+ @return an success BOOL an NSArray of SDArtist objects and NSError which is nil on success.
+ */
+
++(void)simpleSearchArtistsWithString:(NSString*)searchString withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSError * error))completion;
+
+/**
+ Search for Artist.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param sortString      this is the string to set the sorting field. string should be formatted  "{sortColumn} {sortOrder}" when not specified the string is equvalent to "{core desc} {ascending}".
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+@return an success BOOL an NSArray of SDArtist objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
+
++(void)searchArtistsWithString:(NSString*)searchString whoAreStreamable:(BOOL*)streamable withSortString:(NSString*)sortString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+//Release
+/**
+ Search for Release.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param releaseType     Filter results via type of album,single,video as a string.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ @return an success BOOL an NSArray of SDRelease objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchReleasesWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable ofType:(NSString*)releaseType fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+//tracks
+/**
+ Search for Tracks.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param packageIdsString    string of desired packages seperated by comma.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ 
+ @return an success BOOL an NSArray of SDTrack objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchTracksWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable forPackageIds:(NSString*)packageIdsString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+@end

--- a/Classes/ios/SDSearchHelper.h
+++ b/Classes/ios/SDSearchHelper.h
@@ -1,0 +1,72 @@
+//
+//  SDSearch.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 15/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDSearchHelper : NSObject
+
+//Artist
+/**
+ a basic search.
+ 
+ @param searchString    the string to search for.
+ 
+ @return an success BOOL an NSArray of SDArtist objects and NSError which is nil on success.
+ */
+
++(void)simpleSearchArtistsWithString:(NSString*)searchString withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSError * error))completion;
+
+/**
+ Search for Artist.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param sortString      this is the string to set the sorting field. string should be formatted  "{sortColumn} {sortOrder}" when not specified the string is equvalent to "{core desc} {ascending}".
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+@return an success BOOL an NSArray of SDArtist objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
+
++(void)searchArtistsWithString:(NSString*)searchString whoAreStreamable:(BOOL*)streamable withSortString:(NSString*)sortString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+//Release
+/**
+ Search for Release.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param releaseType     Filter results via type of album,single,video as a string.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ @return an success BOOL an NSArray of SDRelease objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchReleasesWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable ofType:(NSString*)releaseType fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+//tracks
+/**
+ Search for Tracks.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param packageIdsString    string of desired packages seperated by comma.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ 
+ @return an success BOOL an NSArray of SDTrack objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchTracksWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable forPackageIds:(NSString*)packageIdsString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+@end

--- a/Classes/ios/SDStreamLogging.h
+++ b/Classes/ios/SDStreamLogging.h
@@ -1,0 +1,65 @@
+//
+//  SDStreamLogging.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 14/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDStreamLogging : NSObject
+
+
+#pragma mark - enums for the methods so we can send the correct string to the api.
+
+// how was the track played for subscription user.
+typedef enum Playmode:NSUInteger{
+    playModeOnline = 0,
+    playModeOffline = 1,
+    playModeOnlineCached = 2
+} Playmode;
+
+// the reason playback ended for catalouge stream.
+typedef enum endReason: NSUInteger {
+    endedNaturalEnd = 0,
+    endedUserSkipped = 1,
+    endedOther = 2
+} endReason;
+
+
+#pragma mark - stream reporting methods.
+
+/**
+ Report a subscription stream.
+ 
+ @param trackID         the 7digital id for the track.
+ @param releaseID       the 7digital release id the track is from.
+ @param trackFormatID   Format id of the track usually a 2 digit int.
+ @param playDate        the date with time the stream begun.
+ @param timePlayed      the duration of the play, send 0 if it was just precaching.
+ @param playmode        enum starting with playMode for offline, online, onlineCached.
+ 
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++(void) reportSubscriptionStreamForTrack:(int)trackID fromRelease:(int)releaseID trackFormatID:(int)trackformatID datePlayed:(NSDate*)playDate totalTimePlayed:(float)timePlayed forPlaymode:(Playmode)playmode withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+ Sign up a new partner user.
+ 
+ @param trackID         the 7digital id for the track.
+ @param releaseID       the 7digital release id the track is from.
+ @param trackFormatID   Format id of the track usually a 2 digit int.
+ @param playDate        the date with time the stream begun.
+ @param timePlayed      the duration of the play, send 0 if it was just precaching.
+ @param userID          the users unique identifier.
+ @param endReason       enum starting with ended for naturalEnd, userSkipped, other.
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++(void) reportCatalougueStreamForTrack:(int)trackID fromRelease:(int)releaseID trackFormatID:(int)trackformatID datePlayed:(NSDate*)playDate totalTimePlayed:(float)timePlayed userID:(NSString*)userID endedDueTo:(endReason*)endReason withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+@end

--- a/Classes/ios/SDStreamTrackUrl.h
+++ b/Classes/ios/SDStreamTrackUrl.h
@@ -1,0 +1,49 @@
+//
+//  SDStreamTrackUrl.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDStreamTrackUrl : NSObject
+
+/**
+ Get a locker streaming url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)lockerStreamUrlForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+/**
+ Get a locker subscription url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)subscriptionStreamForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+/**
+ Get a radio Stream track url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)radioStreamForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+@end

--- a/Classes/ios/SDTrack.h
+++ b/Classes/ios/SDTrack.h
@@ -12,7 +12,7 @@
 
 /**
  
- This is an object to represent a 7Digital Track
+ This is an object to represent a 7digital Track
  
  */
 
@@ -26,6 +26,8 @@
 
 @property (assign, nonatomic) NSInteger trackNumber;
 
+@property (assign, nonatomic) NSInteger discNumber;
+
 @property (assign, nonatomic) NSInteger duration;
 
 @property (strong, nonatomic) NSString *isrc; //International Standard Recording Code
@@ -34,7 +36,11 @@
 
 @property (strong, nonatomic) SDArtist *artist;
 
+@property (strong, nonatomic) NSString *performingArtistString;
+
 @property (strong, nonatomic) NSArray *downloadUrls;
+
+@property (assign, nonatomic) BOOL availible;
 
 //As some tracks have a limit on how many times a user can download a track.
 @property (assign, nonatomic) NSInteger downloadsRemainingCount;

--- a/Classes/ios/SDUserAccountSetup.h
+++ b/Classes/ios/SDUserAccountSetup.h
@@ -1,0 +1,68 @@
+//
+//  SDUserAccountSetup.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 11/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SDAPIResponse;
+
+@interface SDUserAccountSetup : NSObject
+
+#pragma mark - New user creation
+/** 
+    Sign up a new user for an 7digital account
+ 
+    @param email        the users email adress.
+    @param password     the users desired password.
+ 
+    @return an success BOOL and NSError which is nil on success.
+*/
++ (void)newUserWithEmail:(NSString*)email andPassword:(NSString*)password withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+ Sign up a new partner user
+ 
+ @param partnerID              your partner ID.
+ @param signUpEmailAddress     your users email address.
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
++ (void)newPartnerUser:(NSString*)partnerID withEmailAddress:(NSString*)signUpEmailAddress withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+    Set up a user for streaming
+ 
+    @param allowOffline         whether or not the user has access to offline streaming
+    @param usersCountry         country code of the user
+ 
+    @return completion contains a success BOOL and NSError which is nil on success
+ 
+ */
+
++ (void)authoriseDeviceForUnlimitedStreaming:(BOOL)allowOffline usersCountry:(NSString*)country withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
++ (void)subscriptionStatusForCurrentUserWithCountry:(NSString*)country withCompletion:(void(^)(SDAPIResponse *response, NSString *level, NSDate *expiryDate, NSError * error))completion;
+
+#pragma mark - Authorize device for off-line streaming
+//Used to authorise a device for offline mode. After authorised, a device can download in bulk from the offline/subscription endpoint.
+
+/**
+ Authorise Offline Streaming for the user
+ 
+ @param allowUnlimitedStreaming        bool for authorise or unauthorise
+ @param country                        the users country of usage (this may be removed later)
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++ (void)authoriseDeviceForOfflineStreaming:(BOOL)allowOffline usersCountry:(NSString*)country withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+
+
+
+
+@end

--- a/Classes/ios/SevenDigital.h
+++ b/Classes/ios/SevenDigital.h
@@ -9,10 +9,11 @@
 #import <Foundation/Foundation.h>
 #import "SDAPIRequest.h"
 #import "SDAPIResponse.h"
-#import "SDLocker.h"
-#import "SDMedia.h"
-#import "SDPlaylist.h"
 #import "SDDownloadUrl.h"
+#import "SDLockerHelper.h"
+#import "SDMedia.h"
+#import "SDPlaylistHelper.h"
+#import "SDUserAccountSetup.h"
 
 #import <UIKit/UIKit.h>
 
@@ -22,6 +23,8 @@
 
 @property (nonatomic, readonly) NSString *currentUser;
 @property (nonatomic, readonly) BOOL isCurrentUserAuthenticated;
+
+@property (nonatomic, retain) NSNumber * serverOffset;
 
 /**@brief reusable singleton for calling api methods*/
 + (SevenDigital *)sharedInstance;
@@ -74,18 +77,16 @@
  @param url             The path as an NSURL that we would like to request from
  @param params          A dictionary with any url parameters
  
- @returns an oauth-ready NSURL
+ @return an oauth-ready NSURL
  
  */
 
 - (NSURL *)authenticatedURLWithURL:(NSURL *)url params:(NSDictionary *)params;
 
-
 //
 //\\Authentication with the 7digital API
 //
 // Login and logout methods
-
 
 
 
@@ -96,7 +97,6 @@
  
  */
 -(void)presentLoginWebViewFromView:(UIViewController*)presentingFromView;
-
 
 
 
@@ -129,8 +129,13 @@
 
 - (void)logout;
 
+/** 
+    methods to force the calculating the server offset.
+    this should usually generate itself on requests but i like to call it on applicationDidFinishLaunching
+ */
+- (void)calculateServerOffsetWithCompletion:(void(^)())completion;
 
-
+- (void)calculateServerOffset;
 
 
 @end

--- a/Example Alternative Integration/APITestProject/source/SDAPIRequest.h
+++ b/Example Alternative Integration/APITestProject/source/SDAPIRequest.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) NSDictionary *params;
 @property (nonatomic, copy) NSData * bodyData;
 @property (nonatomic, strong) NSURL *fixedURL;
+@property (nonatomic, strong) NSString *acceptHeader;
 
 - (id)initWithPath:(NSString *)path;
 - (id)initWithPath:(NSString *)path params:(NSDictionary *)params;

--- a/Example Alternative Integration/APITestProject/source/SDArtist.h
+++ b/Example Alternative Integration/APITestProject/source/SDArtist.h
@@ -24,6 +24,9 @@
 
 @property (strong, nonatomic) NSString *SDURL;
 
+//This isnt returned by the locker call itself, but is in the search api. which is what we currently use to get artist images.
+@property (strong, nonatomic) NSString *imageURL;
+
 - (id)initWithDictionary:(NSDictionary *)apiDictionary;
 
 

--- a/Example Alternative Integration/APITestProject/source/SDLockerHelper.h
+++ b/Example Alternative Integration/APITestProject/source/SDLockerHelper.h
@@ -1,0 +1,27 @@
+//
+//  SDLocker.h
+//  7digital
+//
+//  Created by Daniel Too on 3/04/14.
+//  Copyright (c) 2014 7digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SDRelease.h"
+#import "SDTrack.h"
+#import "SDArtist.h"
+
+/**
+ 
+ This is a request to return releases from a user's locker (library of all purchased tracks).
+ 
+ */
+
+@class SDAPIResponse;
+
+@interface SDLockerHelper : NSObject
+
++ (void)requestLockerForCurrentUserWithParams:(NSDictionary *)params completion:(void(^)(SDAPIResponse *response, NSArray *releasesArray, NSError *error))completion;
+
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDMedia.h
+++ b/Example Alternative Integration/APITestProject/source/SDMedia.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, kSDMediaType) {
 
 /**
  Returns a URL for a 7digital track appropriate for streaming or downloading.  The NSURL will contain all of the appropriate oAuth parameters for the logged in user.
- See the 7Digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
+ See the 7digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
  
  @see kSDMediaType for
  @param track           The SDTrack object for the song
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, kSDMediaType) {
 
 /**
  Returns a URL for a 7digital track appropriate for a preview stream.  The NSURL will contain all of the appropriate oAuth parameters for the logged in user.
- See the 7Digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
+ See the 7digital media API at http://developer.7digital.com/resources/api-docs/media-delivery-api
  
  @param track           The SDTrack object for the song
  

--- a/Example Alternative Integration/APITestProject/source/SDPlaylist.h
+++ b/Example Alternative Integration/APITestProject/source/SDPlaylist.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SDPlaylistTrack.h"
 
 @interface SDPlaylist : NSObject
 
@@ -17,9 +18,35 @@
  @param title           The title of your playlist
  @param tracksArray     A array with the track dictionaries inside.
  
- @returns the playlistID
+ @return the playlistID
  **/
 
-+(void)createPlaylistWithTitle:(NSString*)title withTracksArray:(NSArray*)tracksArray returningPlaylistID:(void(^)(NSString* playlistID))completion;
++(void)createPlaylistWithTitle:(NSString*)title withTracksArray:(NSArray*)tracksArray returningPlaylistID:(void(^)(NSString* playlistID, NSArray* tracksArray))completion;
+
+
+/**
+ Get an array of users playlists.
+ 
+ @param pageSize    Optional parameter for how many playlists you want to return from your call.
+ @param page        an optional parameter to set a specific page of of playlists you want returned
+ @param userID      a optional parameter to returns a specific users public playlists
+ 
+ @return an array of SDPlaylistHeader's
+ **/
+
++(void)getPlaylists:(NSInteger*)pageSize page:(NSInteger*)page forOptionalSpecificUserID:(NSString*)userID returningPlaylistsArray:(void(^)(NSArray * playlistsArray, NSInteger* totalNumberOfPlaylists, NSError * error)) completion;
+
+
+/**
+ Get tracks for a specific playlist.
+ 
+ @param playlsitID    Optional parameter for how many playlists you want to return from your call.
+ 
+ @return the array of playlistTracks and a NSError for unsuccessful states.
+ **/
+
++(void)getPlaylistTracksForPlaylistID:(NSString*)playlistID withCompetion:(void(^)(NSArray * playlistTrackArray, NSError * error))completion;
+
 
 @end
+

--- a/Example Alternative Integration/APITestProject/source/SDPlaylistHeader.h
+++ b/Example Alternative Integration/APITestProject/source/SDPlaylistHeader.h
@@ -1,0 +1,24 @@
+//
+//  SDPlaylistHeader.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistHeader : NSObject
+
+
+@property (nonatomic,strong) NSString * playlistTitle;
+@property (nonatomic,strong) NSString * playlistID;
+@property (nonatomic) BOOL publicPlaylist;
+@property (nonatomic,strong) NSDate * lastUpdated;
+@property (nonatomic) NSInteger * trackCount;
+@property (nonatomic,strong) NSString * imageURlString;
+//these two I dont use so I'm just gonna pass you the array of NSDictionaries.
+@property (nonatomic,strong) NSArray * annotations;
+@property (nonatomic,strong) NSArray * links;
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDPlaylistHelper.h
+++ b/Example Alternative Integration/APITestProject/source/SDPlaylistHelper.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "SDPlaylistTrack.h"
 
-@interface SDPlaylist : NSObject
+@interface SDPlaylistHelper : NSObject
 
 
 /**

--- a/Example Alternative Integration/APITestProject/source/SDPlaylistMetadata.h
+++ b/Example Alternative Integration/APITestProject/source/SDPlaylistMetadata.h
@@ -1,0 +1,29 @@
+//
+//  SDPlaylistHeader.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistMetadata : NSObject
+
+@property (nonatomic, strong) NSString *playlistTitle;
+
+@property (nonatomic, strong) NSString *playlistID;
+
+@property (nonatomic, assign) BOOL publicPlaylist;
+
+@property (nonatomic, strong) NSDate *lastUpdated;
+
+@property (nonatomic, assign) NSInteger trackCount;
+
+@property (nonatomic, strong) NSString *imageURlString;
+
+//these two I dont use so I'm just gonna pass you the array of NSDictionaries.
+@property (nonatomic, strong) NSArray *annotations;
+@property (nonatomic, strong) NSArray *links;
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDPlaylistTrack.h
+++ b/Example Alternative Integration/APITestProject/source/SDPlaylistTrack.h
@@ -1,0 +1,48 @@
+//
+//  SDPlaylistTrack.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 30/09/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDPlaylistTrack : NSObject
+
+//the unique identifer for this track in the playlist.
+@property (strong, nonatomic) NSString * playlistTrackID;
+
+//the general track ID (may match to a track of origin 7digital, iTunes, Android)
+@property (strong, nonatomic) NSString * trackID;
+
+@property (strong, nonatomic) NSString * trackTitle;
+
+@property (strong, nonatomic) NSString * artistAppearsAs;
+
+//release properties
+@property (assign, nonatomic) NSInteger releaseId;
+
+@property (strong, nonatomic) NSString * releaseTitle;
+
+@property (strong, nonatomic) NSString * releaseArtistAppearsAs;
+
+@property (strong, nonatomic) NSString * releaseVersion;
+
+//the source of the track (i'm using "7digital" for 7digital tracks, and "itunes" for my users itunes tracks)
+@property (strong, nonatomic) NSString * source;
+
+@property (strong, nonatomic) NSString * audioUrl;
+
+@property (strong, nonatomic) NSDictionary * user;
+
+@property (strong, nonatomic) NSDate * dateAdded;
+
+@property (strong, nonatomic) NSString * imageString;
+
+
+//population method pass a single dictionary from the tracks array to populate
+- (id)initWithDictionary:(NSDictionary *)apiDictionary;
+
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDRelease.h
+++ b/Example Alternative Integration/APITestProject/source/SDRelease.h
@@ -12,7 +12,7 @@
 
 /**
  
- This is an object to represent a 7Digital Release (An album, single, EP etc)
+ This is an object to represent a 7digital Release (An album, single, EP etc)
  
  */
 
@@ -38,6 +38,8 @@
 
 @property (strong, nonatomic) NSArray *tracks;
 
+//unfortunately some albulms get taken down from 7digital by the rights holders this indicates if it has.
+@property (assign, nonatomic) BOOL available;
 
 /**
  

--- a/Example Alternative Integration/APITestProject/source/SDSearch.h
+++ b/Example Alternative Integration/APITestProject/source/SDSearch.h
@@ -1,0 +1,72 @@
+//
+//  SDSearch.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 15/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDSearch : NSObject
+
+//Artist
+/**
+ a basic search.
+ 
+ @param searchString    the string to search for.
+ 
+ @return an success BOOL an NSArray of SDArtist objects and NSError which is nil on success.
+ */
+
++(void)simpleSearchArtistsWithString:(NSString*)searchString withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSError * error))completion;
+
+/**
+ Search for Artist.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param sortString      this is the string to set the sorting field. string should be formatted  "{sortColumn} {sortOrder}" when not specified the string is equvalent to "{core desc} {ascending}".
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+@return an success BOOL an NSArray of SDArtist objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
+
++(void)searchArtistsWithString:(NSString*)searchString whoAreStreamable:(BOOL*)streamable withSortString:(NSString*)sortString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+//Release
+/**
+ Search for Release.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param releaseType     Filter results via type of album,single,video as a string.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ @return an success BOOL an NSArray of SDRelease objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchReleasesWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable ofType:(NSString*)releaseType fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+//tracks
+/**
+ Search for Tracks.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param packageIdsString    string of desired packages seperated by comma.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ 
+ @return an success BOOL an NSArray of SDTrack objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchTracksWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable forPackageIds:(NSString*)packageIdsString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDSearchHelper.h
+++ b/Example Alternative Integration/APITestProject/source/SDSearchHelper.h
@@ -1,0 +1,72 @@
+//
+//  SDSearch.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 15/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDSearchHelper : NSObject
+
+//Artist
+/**
+ a basic search.
+ 
+ @param searchString    the string to search for.
+ 
+ @return an success BOOL an NSArray of SDArtist objects and NSError which is nil on success.
+ */
+
++(void)simpleSearchArtistsWithString:(NSString*)searchString withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSError * error))completion;
+
+/**
+ Search for Artist.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param sortString      this is the string to set the sorting field. string should be formatted  "{sortColumn} {sortOrder}" when not specified the string is equvalent to "{core desc} {ascending}".
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+@return an success BOOL an NSArray of SDArtist objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
+
++(void)searchArtistsWithString:(NSString*)searchString whoAreStreamable:(BOOL*)streamable withSortString:(NSString*)sortString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * artistsArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+//Release
+/**
+ Search for Release.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param releaseType     Filter results via type of album,single,video as a string.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ @return an success BOOL an NSArray of SDRelease objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchReleasesWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable ofType:(NSString*)releaseType fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+//tracks
+/**
+ Search for Tracks.
+ 
+ @param searchString    the string to search for.
+ @param streamable      optional parameter if set will return only streamable or non streamable artists.
+ @param packageIdsString    string of desired packages seperated by comma.
+ @param countryCode     country catalougue the search is being searched against.
+ @param page            what page number you want back, starts with 1.
+ @param pageSize        how many items you want back in a page
+ 
+ 
+ @return an success BOOL an NSArray of SDTrack objects, a count of the number of items that match search parameters and NSError which is nil on success.
+ */
++(void)searchTracksWithString:(NSString*)searchString thatAreStreamable:(BOOL*)streamable forPackageIds:(NSString*)packageIdsString fromCountryCatalougue:(NSString*)countryCode page:(int)page pageSize:(int)pageSize withCompletion:(void(^)(BOOL success, NSArray * releasesArray, NSInteger totalMatchingSearchItems , NSError * error))completion;
+
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDStreamLogging.h
+++ b/Example Alternative Integration/APITestProject/source/SDStreamLogging.h
@@ -1,0 +1,65 @@
+//
+//  SDStreamLogging.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 14/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDStreamLogging : NSObject
+
+
+#pragma mark - enums for the methods so we can send the correct string to the api.
+
+// how was the track played for subscription user.
+typedef enum Playmode:NSUInteger{
+    playModeOnline = 0,
+    playModeOffline = 1,
+    playModeOnlineCached = 2
+} Playmode;
+
+// the reason playback ended for catalouge stream.
+typedef enum endReason: NSUInteger {
+    endedNaturalEnd = 0,
+    endedUserSkipped = 1,
+    endedOther = 2
+} endReason;
+
+
+#pragma mark - stream reporting methods.
+
+/**
+ Report a subscription stream.
+ 
+ @param trackID         the 7digital id for the track.
+ @param releaseID       the 7digital release id the track is from.
+ @param trackFormatID   Format id of the track usually a 2 digit int.
+ @param playDate        the date with time the stream begun.
+ @param timePlayed      the duration of the play, send 0 if it was just precaching.
+ @param playmode        enum starting with playMode for offline, online, onlineCached.
+ 
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++(void) reportSubscriptionStreamForTrack:(int)trackID fromRelease:(int)releaseID trackFormatID:(int)trackformatID datePlayed:(NSDate*)playDate totalTimePlayed:(float)timePlayed forPlaymode:(Playmode)playmode withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+ Sign up a new partner user.
+ 
+ @param trackID         the 7digital id for the track.
+ @param releaseID       the 7digital release id the track is from.
+ @param trackFormatID   Format id of the track usually a 2 digit int.
+ @param playDate        the date with time the stream begun.
+ @param timePlayed      the duration of the play, send 0 if it was just precaching.
+ @param userID          the users unique identifier.
+ @param endReason       enum starting with ended for naturalEnd, userSkipped, other.
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++(void) reportCatalougueStreamForTrack:(int)trackID fromRelease:(int)releaseID trackFormatID:(int)trackformatID datePlayed:(NSDate*)playDate totalTimePlayed:(float)timePlayed userID:(NSString*)userID endedDueTo:(endReason*)endReason withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDStreamTrackUrl.h
+++ b/Example Alternative Integration/APITestProject/source/SDStreamTrackUrl.h
@@ -1,0 +1,49 @@
+//
+//  SDStreamTrackUrl.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 22/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SDStreamTrackUrl : NSObject
+
+/**
+ Get a locker streaming url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)lockerStreamUrlForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+/**
+ Get a locker subscription url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)subscriptionStreamForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+/**
+ Get a radio Stream track url.
+ 
+ @param trackID         The 7digital id for the track.
+ @param formatId        Format id of the track usually a 2 digit int.
+ @param countryCode     The date with time the stream begun.
+ 
+ @return an authourised NSURl
+ */
+
++(NSURL*)radioStreamForTrackId:(NSInteger*)trackId desiredFormatId:(NSInteger*)formatID countryCode:(NSString*)countryCode;
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SDTrack.h
+++ b/Example Alternative Integration/APITestProject/source/SDTrack.h
@@ -12,7 +12,7 @@
 
 /**
  
- This is an object to represent a 7Digital Track
+ This is an object to represent a 7digital Track
  
  */
 
@@ -26,6 +26,8 @@
 
 @property (assign, nonatomic) NSInteger trackNumber;
 
+@property (assign, nonatomic) NSInteger discNumber;
+
 @property (assign, nonatomic) NSInteger duration;
 
 @property (strong, nonatomic) NSString *isrc; //International Standard Recording Code
@@ -34,7 +36,11 @@
 
 @property (strong, nonatomic) SDArtist *artist;
 
+@property (strong, nonatomic) NSString *performingArtistString;
+
 @property (strong, nonatomic) NSArray *downloadUrls;
+
+@property (assign, nonatomic) BOOL availible;
 
 //As some tracks have a limit on how many times a user can download a track.
 @property (assign, nonatomic) NSInteger downloadsRemainingCount;

--- a/Example Alternative Integration/APITestProject/source/SDUserAccountSetup.h
+++ b/Example Alternative Integration/APITestProject/source/SDUserAccountSetup.h
@@ -1,0 +1,68 @@
+//
+//  SDUserAccountSetup.h
+//  SevenDigital
+//
+//  Created by Ryan Smale on 11/12/15.
+//  Copyright © 2015 7 Digital. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class SDAPIResponse;
+
+@interface SDUserAccountSetup : NSObject
+
+#pragma mark - New user creation
+/** 
+    Sign up a new user for an 7digital account
+ 
+    @param email        the users email adress.
+    @param password     the users desired password.
+ 
+    @return an success BOOL and NSError which is nil on success.
+*/
++ (void)newUserWithEmail:(NSString*)email andPassword:(NSString*)password withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+ Sign up a new partner user
+ 
+ @param partnerID              your partner ID.
+ @param signUpEmailAddress     your users email address.
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
++ (void)newPartnerUser:(NSString*)partnerID withEmailAddress:(NSString*)signUpEmailAddress withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+/**
+    Set up a user for streaming
+ 
+    @param allowOffline         whether or not the user has access to offline streaming
+    @param usersCountry         country code of the user
+ 
+    @return completion contains a success BOOL and NSError which is nil on success
+ 
+ */
+
++ (void)authoriseDeviceForUnlimitedStreaming:(BOOL)allowOffline usersCountry:(NSString*)country withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
++ (void)subscriptionStatusForCurrentUserWithCountry:(NSString*)country withCompletion:(void(^)(SDAPIResponse *response, NSString *level, NSDate *expiryDate, NSError * error))completion;
+
+#pragma mark - Authorize device for off-line streaming
+//Used to authorise a device for offline mode. After authorised, a device can download in bulk from the offline/subscription endpoint.
+
+/**
+ Authorise Offline Streaming for the user
+ 
+ @param allowUnlimitedStreaming        bool for authorise or unauthorise
+ @param country                        the users country of usage (this may be removed later)
+ 
+ @return an success BOOL and NSError which is nil on success.
+ */
+
++ (void)authoriseDeviceForOfflineStreaming:(BOOL)allowOffline usersCountry:(NSString*)country withCompletion:(void(^)(BOOL success, NSError * error))completion;
+
+
+
+
+
+@end

--- a/Example Alternative Integration/APITestProject/source/SevenDigital.h
+++ b/Example Alternative Integration/APITestProject/source/SevenDigital.h
@@ -9,10 +9,11 @@
 #import <Foundation/Foundation.h>
 #import "SDAPIRequest.h"
 #import "SDAPIResponse.h"
-#import "SDLocker.h"
-#import "SDMedia.h"
-#import "SDPlaylist.h"
 #import "SDDownloadUrl.h"
+#import "SDLockerHelper.h"
+#import "SDMedia.h"
+#import "SDPlaylistHelper.h"
+#import "SDUserAccountSetup.h"
 
 #import <UIKit/UIKit.h>
 
@@ -22,6 +23,8 @@
 
 @property (nonatomic, readonly) NSString *currentUser;
 @property (nonatomic, readonly) BOOL isCurrentUserAuthenticated;
+
+@property (nonatomic, retain) NSNumber * serverOffset;
 
 /**@brief reusable singleton for calling api methods*/
 + (SevenDigital *)sharedInstance;
@@ -74,18 +77,16 @@
  @param url             The path as an NSURL that we would like to request from
  @param params          A dictionary with any url parameters
  
- @returns an oauth-ready NSURL
+ @return an oauth-ready NSURL
  
  */
 
 - (NSURL *)authenticatedURLWithURL:(NSURL *)url params:(NSDictionary *)params;
 
-
 //
 //\\Authentication with the 7digital API
 //
 // Login and logout methods
-
 
 
 
@@ -96,7 +97,6 @@
  
  */
 -(void)presentLoginWebViewFromView:(UIViewController*)presentingFromView;
-
 
 
 
@@ -129,8 +129,13 @@
 
 - (void)logout;
 
+/** 
+    methods to force the calculating the server offset.
+    this should usually generate itself on requests but i like to call it on applicationDidFinishLaunching
+ */
+- (void)calculateServerOffsetWithCompletion:(void(^)())completion;
 
-
+- (void)calculateServerOffset;
 
 
 @end

--- a/SevenDigital.podspec
+++ b/SevenDigital.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SevenDigital"
-  s.version      = "1.1.4"
+  s.version      = “1.4.0”
   s.summary      = "The 7digital iOS SDK helps you use the 7digital API."
 
   s.description  = <<-DESC
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.author       = { "7digital" => "support@7digital.com" }
 
   s.platform     = :ios, '7.0'
-  s.source       = { :git => "https://github.com/7digital/7digital-iOS-SDK.git" , :tag => '1.1.4' }
+  s.source       = { :git => "https://github.com/7digital/7digital-iOS-SDK.git" , :tag => ‘1.4.0’ }
   s.source_files  = 'Classes', 'Classes/**/*.{h,m}'
   s.exclude_files = 'Classes/Exclude'
   s.public_header_files = 'Classes/**/*.h'


### PR DESCRIPTION
Provides methods to the users of the SDK to access new parts of the 7digital api
* Streaming endpoints and their required logging endpoints. 
* Search Api
* Getting (read) playlists and playlist tracks.
* Setting the default stream to format 56